### PR TITLE
Add missing security utilities and file validation helpers

### DIFF
--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -90,6 +90,11 @@ def get_async_session():
         return SessionLocal()
 
 
+def get_db_session() -> Session:
+    """Get a synchronous database session."""
+    return SessionLocal()
+
+
 async def init_db() -> None:
     """
     Initialize database with pgvector extension

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,3 @@
+from main import app
+
+__all__ = ["app"]

--- a/backend/app/utils/logging.py
+++ b/backend/app/utils/logging.py
@@ -31,6 +31,11 @@ except ImportError:
         return data
 
 
+def setup_privacy_logging() -> None:
+    """Basic logging setup respecting privacy settings."""
+    logging.basicConfig(level=logging.INFO)
+
+
 class SanitizedFormatter(logging.Formatter):
     """Custom formatter that sanitizes sensitive data."""
     
@@ -147,9 +152,9 @@ def sanitize_log_data(data: Any) -> Any:
 
 class SecurityLogger:
     """Specialized logger for security events."""
-    
-    def __init__(self):
-        self.logger = logging.getLogger('security')
+
+    def __init__(self, name: str = "security"):
+        self.logger = logging.getLogger(name)
         self._setup_security_logger()
     
     def _setup_security_logger(self):

--- a/backend/app/utils/privacy_service.py
+++ b/backend/app/utils/privacy_service.py
@@ -324,5 +324,6 @@ class PrivacyService:
         return recommendations
 
 
-# Global privacy service instance
+# Global privacy service instances
 privacy_service = PrivacyService()
+privacy_manager = privacy_service


### PR DESCRIPTION
## Summary
- add legacy-compatible file validation helpers and async validation function
- introduce basic security validator, hashing helper, and access control utilities
- expose app module and privacy manager for FastAPI routing

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=. pytest -c /dev/null tests/test_main.py tests/test_document_upload.py::TestFileValidation::test_get_file_type tests/test_document_upload.py::TestFileValidation::test_is_supported_file_type`

------
https://chatgpt.com/codex/tasks/task_e_68a0a28b532883298c9c970d1b47f59c